### PR TITLE
Fixes to PS3EYE distortion calibration

### DIFF
--- a/src/psmoveservice/PSMoveTracker/PS3EyeTracker.h
+++ b/src/psmoveservice/PSMoveTracker/PS3EyeTracker.h
@@ -36,7 +36,6 @@ public:
 	inline CommonHSVColorRangeTable *getOrAddColorRangeTable(const std::string &table_name);
     
     bool is_valid;
-    long version;
     long max_poll_failure_count;
     double exposure;
 	double gain;
@@ -60,6 +59,7 @@ public:
 	std::vector<CommonHSVColorRangeTable> DeviceColorPresets;
 
     static const int CONFIG_VERSION;
+	static const int LENS_CALIBRATION_VERSION;
 };
 
 struct PS3EyeTrackerState : public CommonDeviceState


### PR DESCRIPTION
* Adding version id to lens distortion calibration to force update distortion parameters while leaving rest of camera config alone
* Computed default distortion parameters for PS3EYE camera that seem to give more correct results:
    "distortionK1": "-0.10771770030260086"
    "distortionK2": "0.1213262677192688"
    "distortionK3": "0.04875476285815239"
    "distortionP1": "0.00091733073350042105"
    "distortionP2": "0.00010589254816295579"