### PR TITLE
Assorted tweaks and fixes to build scripts

### DIFF
--- a/BuildOfficialDistribution.bat
+++ b/BuildOfficialDistribution.bat
@@ -120,16 +120,16 @@ IF %ERRORLEVEL% NEQ 0 (
 popd
 
 :: Find the distribution folder
-For /D %%D in ("PSMoveService_*") Do (
-    set "DISTRIBUTION_LABEL=%%~fD"
-)
-if NOT DEFINED DISTRIBUTION_LABEL (
+if exist "install/version.txt" (
+    set /p DISTRIBUTION_LABEL=<"install/version.txt"
+    echo "Found distribution folder for version: %DISTRIBUTION_LABEL%"
+) else (
     echo "Failed to find the distribution folder generated from the builds!"
     goto failure
 )
 
 :: Create the distribution zip from the Release|x64 folder
-set "DISTRIBUTION_FOLDER=%DISTRIBUTION_LABEL%\Win64\Release"
+set "DISTRIBUTION_FOLDER=install\Win64\Release"
 set "DISTRIBUTION_ZIP=%DISTRIBUTION_LABEL%.zip"
 echo "Creating distribution zip (%DISTRIBUTION_ZIP%) from: %DISTRIBUTION_FOLDER%"
 powershell -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::CreateFromDirectory('%DISTRIBUTION_FOLDER%', '%DISTRIBUTION_ZIP%'); }"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,10 @@ include(cmake/Environment.cmake)
 include(cmake/Version.cmake)
 
 set(PSM_PROJECT_NAME "PSMoveService_${PSM_VERSION_STRING}")
-set(PSM_DEBUG_INSTALL_PATH "${ROOT_DIR}/${PSM_PROJECT_NAME}/${ARCH_LABEL}/Debug")
-set(PSM_RELEASE_INSTALL_PATH "${ROOT_DIR}/${PSM_PROJECT_NAME}/${ARCH_LABEL}/Release")
+set(PSM_DEBUG_INSTALL_PATH "${ROOT_DIR}/install/${ARCH_LABEL}/Debug")
+set(PSM_RELEASE_INSTALL_PATH "${ROOT_DIR}/install/${ARCH_LABEL}/Release")
+file(MAKE_DIRECTORY "${ROOT_DIR}/install")
+file(WRITE "${ROOT_DIR}/install/version.txt" "${PSM_PROJECT_NAME}")
 
 include(cmake/ThirdParty.cmake)
 

--- a/InitialSetup_Win32.bat
+++ b/InitialSetup_Win32.bat
@@ -21,13 +21,13 @@ set "psCommand="(new-object -COM 'Shell.Application')^
 for /f "usebackq delims=" %%I in (`powershell %psCommand%`) do set "BOOST_ROOT_PATH=%%I"
 if NOT DEFINED BOOST_ROOT_PATH (goto failure)
 
+:build_thirdparty
+
 :: Write out the paths to a config batch file
 del SetBuildVars_Win32.bat
 echo @echo off >> SetBuildVars_Win32.bat
 echo set BOOST_ROOT_PATH=%BOOST_ROOT_PATH% >> SetBuildVars_Win32.bat
 echo set BOOST_LIB_PATH=%BOOST_ROOT_PATH%/lib32-msvc-14.0 >> SetBuildVars_Win32.bat
-
-:build_thirdparty
 
 :: Add MSVC build tools to the path
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86

--- a/InitialSetup_X64.bat
+++ b/InitialSetup_X64.bat
@@ -20,13 +20,13 @@ set "psCommand="(new-object -COM 'Shell.Application')^
 for /f "usebackq delims=" %%I in (`powershell %psCommand%`) do set "BOOST_ROOT_PATH=%%I"
 if NOT DEFINED BOOST_ROOT_PATH (goto failure)
 
+:build_thirdparty
+
 :: Write out the paths to a config batch file
 del SetBuildVars_x64.bat
 echo @echo off >> SetBuildVars_x64.bat
 echo set BOOST_ROOT_PATH=%BOOST_ROOT_PATH% >> SetBuildVars_x64.bat
 echo set BOOST_LIB_PATH=%BOOST_ROOT_PATH%/lib64-msvc-14.0 >> SetBuildVars_x64.bat
-
-:build_thirdparty
 
 :: Add MSVC build tools to the path
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64


### PR DESCRIPTION
* Files are now copied to ${ROOT_DIR}/install/${ARCH_LABEL}/<CONFIGURATION> instead of ${ROOT_DIR}/${PSM_PROJECT_NAME}/${ARCH_LABEL}/<CONFIGURATION> when running the "INSTALL" project
* Fixed issue with BuildOfficialDistribution.bat script failing to find OpenCV cmake files